### PR TITLE
Fix the length attribute of enclosure tag - Podcast feed

### DIFF
--- a/_posts/2012-10-07-zofe-0-apresentacao-do-zone-of-front-enders.md
+++ b/_posts/2012-10-07-zofe-0-apresentacao-do-zone-of-front-enders.md
@@ -5,6 +5,7 @@ episodeID: 'ep0'
 mosaico: http://i.imgur.com/HwwDi.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 audio: http://zofe.com.br/episodios/zofe-0-apresentacao
+audio_file_length: 23211281
 duration: '48:21'
 durationMeta: T48M21S
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155514652%3Fsecret_token%3Ds-qCPhX&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2012-10-18-zofe-1-agora-e-pra-valer.md
+++ b/_posts/2012-10-18-zofe-1-agora-e-pra-valer.md
@@ -5,6 +5,7 @@ episodeID: 'ep1'
 mosaico: http://i.imgur.com/HwwDi.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 audio: http://zofe.com.br/episodios/zofe-01-agora-e-pra-valer
+audio_file_length: 26040656
 duration: '54:15'
 durationMeta: T54M15S
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155516820%3Fsecret_token%3Ds-cb53Q&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2012-11-02-zofe-2-beijo-no-coracao.md
+++ b/_posts/2012-11-02-zofe-2-beijo-no-coracao.md
@@ -5,6 +5,7 @@ episodeID: 'ep2'
 mosaico: http://i.imgur.com/ZSyFi.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 audio: http://zofe.com.br/episodios/zofe-02-beijo-no-coracao
+audio_file_length: 27300803
 duration: '56:52'
 durationMeta: T56M52S
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155517102%3Fsecret_token%3Ds-9P19G&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2012-11-20-zofe-3-carreira-em-front-end.md
+++ b/_posts/2012-11-20-zofe-3-carreira-em-front-end.md
@@ -5,6 +5,7 @@ episodeID: 'ep3'
 mosaico: http://i.imgur.com/K5Rrl.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 audio: http://zofe.com.br/episodios/zofe-03-carreira-em-front-end
+audio_file_length: 32638769
 duration: '1:07:59'
 durationMeta: T1H07M59S
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155517497%3Fsecret_token%3Ds-3DZIw&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2013-01-24-zofe-4-todos-os-segredos-do-google.md
+++ b/_posts/2013-01-24-zofe-4-todos-os-segredos-do-google.md
@@ -5,6 +5,7 @@ episodeID: 'ep4'
 mosaico: http://i.imgur.com/YOd4ID5.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 audio: http://zofe.com.br/episodios/zofe-04-todos-os-segredos-do-google
+audio_file_length: 41855415
 duration: '1:27:01'
 durationMeta: T1H27M01S
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155518025%3Fsecret_token%3Ds-dnxS0&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2013-02-09-zofe-5-perca-peso-pergunte-me-como.md
+++ b/_posts/2013-02-09-zofe-5-perca-peso-pergunte-me-como.md
@@ -5,6 +5,7 @@ episodeID: 'ep5'
 mosaico: http://i.imgur.com/HGILa8T.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 audio: http://zofe.com.br/episodios/zofe-05-perca-peso-pergunte-me-como
+audio_file_length: 34505374
 duration: '1:11:53'
 durationMeta: T1H11M53S
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155519072%3Fsecret_token%3Ds-VZCQ1&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2013-03-17-zofe-6-o-que-voce-fez-hoje.md
+++ b/_posts/2013-03-17-zofe-6-o-que-voce-fez-hoje.md
@@ -5,6 +5,7 @@ episodeID: 'ep6'
 mosaico: http://i.imgur.com/2eU6yo6.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 audio: http://zofe.com.br/episodios/zofe-06-o-que-voce-fez-hoje
+audio_file_length: 29776668
 duration: '1:11:53'
 durationMeta: T1H11M53S
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155519268%3Fsecret_token%3Ds-d2QoA&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2013-04-26-necessity-is-the-mother-of-invention.md
+++ b/_posts/2013-04-26-necessity-is-the-mother-of-invention.md
@@ -5,6 +5,7 @@ episodeID: 'ep7'
 mosaico: http://i.imgur.com/chJ9Ze2.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 audio: http://zofe.com.br/episodios/zofe-07-necessity-is-the-mother-of-invention
+audio_file_length: 34298388
 duration: '1:09:49'
 durationMeta: T1H09M49S
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155519873%3Fsecret_token%3Ds-vokk4&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2013-06-23-voce-testa-se-o-teste-do-codigo-testado-testavel.md
+++ b/_posts/2013-06-23-voce-testa-se-o-teste-do-codigo-testado-testavel.md
@@ -3,6 +3,7 @@ title: 'ZOFE #8: Você Testa Se O Teste Do Código Testado é Testável?'
 subtitle: 'Testes no Front-end, com Leonardo Balter'
 episodeID: 'ep8'
 audio: http://zofe.com.br/episodios/zofe-08-voce-testa-se-o-teste-do-codigo-testado-testavel
+audio_file_length: 47127777
 mosaico: http://i.imgur.com/yXLfT12.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155520374%3Fsecret_token%3Ds-rmkdQ&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2013-08-16-te-cutuco-no-feice.md
+++ b/_posts/2013-08-16-te-cutuco-no-feice.md
@@ -3,6 +3,7 @@ title: 'ZOFE #9: Te Cutuco No Feice!'
 subtitle: 'Um brasileiro aprontando ALTAS CONFUSÕES no Feice'
 episodeID: 'ep9'
 audio: http://zofe.com.br/episodios/zofe-09-te-cutuco-no-feice
+audio_file_length: 41770981
 mosaico: http://i.imgur.com/6GqkpjC.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155520351%3Fsecret_token%3Ds-AFgXe&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2013-11-02-especial-busque-conhecimento.md
+++ b/_posts/2013-11-02-especial-busque-conhecimento.md
@@ -3,6 +3,7 @@ title: 'ZOFE #10: Especial - Busque Conhecimento'
 subtitle: 'Tudo junto e misturado'
 episodeID: 'ep10'
 audio: http://zofe.com.br/episodios/zofe-10-especial-busque-conhecimento
+audio_file_length: 39110630
 mosaico: http://i.imgur.com/gjPDbTN.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155520702%3Fsecret_token%3Ds-newQ7&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2013-12-31-antes-do-que-vem-depois-e-vice-versa.md
+++ b/_posts/2013-12-31-antes-do-que-vem-depois-e-vice-versa.md
@@ -3,6 +3,7 @@ title: 'ZOFE #11: Antes Do Que Vem Depois e Vice-Versa'
 subtitle: 'E Um Desabafo De Brinde'
 episodeID: 'ep11'
 audio: http://zofe.com.br/episodios/zofe-11-antes-do-que-vem-depois-e-vice-versa
+audio_file_length: 45127897
 mosaico: http://i.imgur.com/0c6CIcp.png
 mosaico_g: 'http://i.imgur.com/xYVJGsa.png'
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155520903%3Fsecret_token%3Ds-ekXmY&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'

--- a/_posts/2014-02-18-loop-vital-para-voce.md
+++ b/_posts/2014-02-18-loop-vital-para-voce.md
@@ -3,6 +3,7 @@ title: 'ZOFE #12: Loop Vital Para Você'
 subtitle: 'E Infinito Para Todos Nós'
 episodeID: 'ep12'
 audio: http://zofe.com.br/episodios/zofe-12-loop-vital-para-voce
+audio_file_length: 35165757
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155521409%3Fsecret_token%3Ds-82kMk&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, loop infinito, vital
 mosaico: http://i.imgur.com/cZADk5g.png

--- a/_posts/2014-04-13-o-exodo-frontendiano.md
+++ b/_posts/2014-04-13-o-exodo-frontendiano.md
@@ -3,6 +3,7 @@ title: 'ZOFE #13: O Êxodo Frontendiano'
 subtitle: 'Você pode estar na Holanda, sei lá, AGORA!'
 episodeID: 'ep13'
 audio: http://zofe.com.br/episodios/zofe-13-o-exodo-frontendiano
+audio_file_length: 55720075
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155521873%3Fsecret_token%3Ds-ZeUFb&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, eduardo shiota, shiota, booking
 mosaico: http://i.imgur.com/j0cLYVD.png

--- a/_posts/2014-04-18-minify-mamilos.md
+++ b/_posts/2014-04-18-minify-mamilos.md
@@ -3,6 +3,7 @@ title: 'ZOFE #14.minify(); - Mamilos'
 subtitle: 'Eventos, Brendan Eich e um monte de coisas.'
 episodeID: 'ep14'
 audio: http://zofe.com.br/episodios/zofe-14-minify-mamilos
+audio_file_length: 42254111
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155522556%3Fsecret_token%3Ds-UbRpK&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, minify, eventos, noticias, open-source
 mosaico: http://i.imgur.com/1wFIkwh.png

--- a/_posts/2014-05-01-minify-angularjs.md
+++ b/_posts/2014-05-01-minify-angularjs.md
@@ -3,6 +3,7 @@ title: 'ZOFE #15.minify("ciro nunes"); - AngularJS'
 subtitle: 'Haters gonna LISTEN TO ZOFE!'
 episodeID: 'ep14'
 audio: http://zofe.com.br/episodios/zofe-15-minify-angularjs
+audio_file_length: 51367955
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/155522716%3Fsecret_token%3Ds-Z4tiy&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_artwork=true&amp;show_comments=false&amp;show_user=false&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, minify, eventos, noticias, open-source
 mosaico: http://i.imgur.com/ttlc8Ec.png

--- a/_posts/2014-07-19-imagina-na-copa.md
+++ b/_posts/2014-07-19-imagina-na-copa.md
@@ -3,6 +3,7 @@ title: 'ZOFE #16 - Imagina na Copa'
 subtitle: 'Mais um tempo sem vocês. Mas voltamos!'
 episodeID: 'ep16'
 audio: http://feeds.soundcloud.com/stream/159451103-zofepod-16-imagina-na-copa
+audio_file_length: 52389761
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/159451103%3Fsecret_token%3Ds-WM7bL&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, eventos, noticias, open-source, javascript, nodejs, npm
 mosaico: 'http://i.imgur.com/WKzll1A.png'

--- a/_posts/2014-08-07-tcheretche-tcheretche-tcheretche-tchetche.md
+++ b/_posts/2014-08-07-tcheretche-tcheretche-tcheretche-tchetche.md
@@ -3,6 +3,7 @@ title: 'ZOFE #17 - Tcheretchê Tcheretchê Tcheretchê Tchetchê'
 subtitle: 'Com o grande Miller Medeiros como terceiro membro!'
 episodeID: 'ep17'
 audio: http://feeds.soundcloud.com/stream/162204771-zofepod-17-tcheretche-tcheretche-tcheretche-tchetche
+audio_file_length: 78769200
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/162204771%3Fsecret_token%3Ds-WVmpl&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, eventos, noticias, open-source, javascript, miller medeiros
 mosaico: 'http://i.imgur.com/zBSbaok.png'

--- a/_posts/2014-10-12-zofe-17-ao-vivo-na-webbr-2014.md
+++ b/_posts/2014-10-12-zofe-17-ao-vivo-na-webbr-2014.md
@@ -3,6 +3,7 @@ title: 'ZOFE #18 - Ao Vivo na web.br'
 subtitle: 'Com Reinaldo Ferraz'
 episodeID: 'ep18'
 audio: 'http://feeds.soundcloud.com/stream/171872428-zofepod-zofe-18-ao-vivo-na-webbr'
+audio_file_length: 39509251
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/171872428%3Fsecret_token%3Ds-lwcFc&amp;color=ff5500&amp;auto_play=false&amp;hide_related=true&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, eventos, webbr, reinaldo-ferraz
 mosaico: 'http://i.imgur.com/40Aflgb.png'

--- a/_posts/2014-12-27-zofe-19-seja-voce-mesmo-bundao.md
+++ b/_posts/2014-12-27-zofe-19-seja-voce-mesmo-bundao.md
@@ -3,6 +3,7 @@ title: 'ZOFE #19 - Seja Você Mesmo, Bundão'
 subtitle: 'Com Diego Eis'
 episodeID: 'ep19'
 audio: 'http://feeds.soundcloud.com/stream/183396055-zofepod-zofe-19-seja-voce-mesmo-bundao'
+audio_file_length: 80385563
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/183396055%3Fsecret_token%3Ds-y3c5I&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, diego-eis, tableless
 mosaico: 'http://i.imgur.com/3wwFY7n.png'

--- a/_posts/2015-02-18-zofe-20-dois-ponto-zero.md
+++ b/_posts/2015-02-18-zofe-20-dois-ponto-zero.md
@@ -3,6 +3,7 @@ title: 'ZOFE #20 - Dois Ponto Zero'
 subtitle: 'Tudo novo, sempre, de novo'
 episodeID: 'ep20'
 audio: 'http://feeds.soundcloud.com/stream/192038747-zofepod-zofe-20-dois-ponto-zero-finalmente'
+audio_file_length: 31756319
 soundcloud-player: '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/192038747%3Fsecret_token%3Ds-mwj5H&amp;color=ff5500&amp;auto_play=false&amp;hide_related=false&amp;show_comments=true&amp;show_user=true&amp;show_reposts=false"></iframe>'
 tags: episodio, front-end, zofe, dois
 mosaico: 'http://i.imgur.com/z4hY97Y.jpg'

--- a/feed/podcast.xml
+++ b/feed/podcast.xml
@@ -33,7 +33,7 @@ layout: null
       <itunes:subtitle>{{ post.subtitle | strip_html }}</itunes:subtitle>
       <itunes:summary>{{ post.excerpt | strip_html }}</itunes:summary>
       <itunes:image href="{{ post.mosaico }}" />
-      <enclosure url="{{ post.audio }}.m4a" length="{{ post.duration }}" type="audio/x-m4a" />
+      <enclosure url="{{ post.audio }}.m4a" length="{{ post.audio_file_length }}" type="audio/x-m4a" />
       <guid>{{ post.audio }}.m4a</guid>
       <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
       <itunes:duration>{{ post.duration }}</itunes:duration>


### PR DESCRIPTION
It also adds the `audio_file_length` to the source files of posts.

The length attribute is the size in bytes of the audio file.

You can get this value using cURL. Example:

    curl -I -L http://zofe.com.br/episodios/zofe-0-apresentacao

The "Content-Length" header is what we want. If the URL follow
redirects (which is the case of SoundCloud), you may need to take
the last value for the audio file length (which is the bigger number).

This issue is related to #68 