### PR TITLE
Adding two new tags + fixing post excerpts in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ paginate:  5
 permalink: /posts/:title/
 url:       http://zofe.com.br
 markdown:  Kramdown
-excerpt_separator: ""
+excerpt_separator: someNonsenseString
 
 title: "Zone Of Front-Enders - ZOFE"
 exclude: [

--- a/feed/podcast.xml
+++ b/feed/podcast.xml
@@ -2,7 +2,7 @@
 layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
   <channel>
 
     <title>Zone Of Front-Enders - Podcast</title>
@@ -32,6 +32,12 @@ layout: null
       <itunes:author>Zone of Front-Enders</itunes:author>
       <itunes:subtitle>{{ post.subtitle | strip_html }}</itunes:subtitle>
       <itunes:summary>{{ post.excerpt | strip_html }}</itunes:summary>
+      <description>
+        <![CDATA[ {{ post.excerpt | strip_html }} ]]>
+      </description>
+      <content:encoded>
+        <![CDATA[ {{ post.excerpt }} ]]>
+      </content:encoded>
       <itunes:image href="{{ post.mosaico }}" />
       <enclosure url="{{ post.audio }}.m4a" length="{{ post.duration }}" type="audio/x-m4a" />
       <guid>{{ post.audio }}.m4a</guid>


### PR DESCRIPTION
This PR resumes two commits.
It references to [Issue 68](https://github.com/zofepod/zofe/issues/68).

First, about two new tags. After digging the web I found two tags that were design to provide the description and the content (for the non-Apple podcast catchers), `<description>` and `<content:encoded>` tags respectively.
Both tag's content are the excerpt of the posts, but the difference between them is where they appear: the first is like a description in a list of podcasts as a short descriptive about the episode. The second is the content of when you're inside a podcast episode, with full HTML markup (a common practice between podcasts).
References:
[RSS Board - Description Tag](http://www.rssboard.org/rss-profile#element-channel-description)
[RSS Board - Content Tag](http://www.rssboard.org/rss-profile#namespace-elements-content)
[MDN - Why RSS Content Module is Popular - Including HTML Contents](https://developer.mozilla.org/en-US/docs/Web/RSS/Article/Why_RSS_Content_Module_is_Popular_-_Including_HTML_Contents)

The second commit is about a Jekyll tag. The described RSS podcast tags weren't working correctly (returning blank), so I realized `post.excerpt` wasn't spitting out anything, and in consequence `<itunes:summary>` tags were blank too!
After a little research I figured out `post.excerpt` wasn't being correctly interpreted because of `excerpt_separator: ""` confguration in `_config.yml`, altough the documentation says it's right. So I tried "the other official recommendation" and put a `someNonsenseString` to delimitate the excerpt. So guys, please don't use that thing in your posts :)))
References:
[Jekyll Documentation - post.excerpt](http://jekyllrb.com/docs/troubleshooting/#excerpts)