### PR TITLE
Fix to mark the topics before of the actual time

### DIFF
--- a/assets/js/progress-tracker.js
+++ b/assets/js/progress-tracker.js
@@ -1,9 +1,10 @@
 (function () {
   'use strict';
-
+  
   /**
    * Metodos Auxiliares
    */
+  
 
   var utils = {
     /**
@@ -30,23 +31,23 @@
     },
 
     /**
-     * Encontra, em um array de numeros, o numero
-     * mais proximo de um dado.
+     * Encontra, em um array de numeros, o elemento que é menor e ao mesmo tempo
+     * mais próximo de um número fornecido.
      * @param  {array} where onde procurar
      * @param  {number} num   numero que setta a
      *                        proximidade
      * @return {number}       o numero mais
      *                        proximo daquele passado
      */
-    getNearest: function (where, num) {
+    getNearestSmaller: function (where, num) {
       var c = where[0];
 
       for (var i = 0, N = where.length; i < N; i++)
-        if (Math.abs(num - where[i]) < Math.abs(num - c))
+        if (Math.abs(num - where[i]) < Math.abs(num - c) && num - where[i] >= 0)
           c = where[i];
 
       return c;
-    }
+    },
   };
 
   // para que possamos testar com o Mocha
@@ -82,7 +83,7 @@
     }, {});
 
     // setta o mais proximo como o primeiro
-    currNearest = utils.getNearest(timeMap, 0);
+    currNearest = utils.getNearestSmaller(timeMap, 0);
 
     widget.bind(SC.Widget.Events.READY, function () {
       widget.bind(SC.Widget.Events.PLAY_PROGRESS, highlightTime);
@@ -95,7 +96,7 @@
      */
     function highlightTime (ev) {
       var time = (ev.currentPosition / 1000) | 0;
-      var nearest = utils.getNearest(Object.keys(timeMap), time);
+      var nearest = utils.getNearestSmaller(Object.keys(timeMap), time);
 
       if (currNearest !== nearest) {
         for (var i in timeMap) {

--- a/assets/js/test-progress-tracker.js
+++ b/assets/js/test-progress-tracker.js
@@ -81,30 +81,44 @@ describe('getTime', function() {
   });
 });
 
-describe('getNearest',function () {
-  var getNearest = utils.getNearest;
+describe('getNearestSmaller',function () {
+  var getNearestSmaller = utils.getNearestSmaller;
 
   it('be defined',function () {
-    assert(!!getNearest);
+    assert(!!getNearestSmaller);
   });
-
-  it('return the same point if only one',function () {
-    var actual = getNearest([5], 10);
+  
+  it('return the first if there is no floor',function () {
+    var actual = getNearestSmaller([5], 4);
     var expected = 5;
 
     assert.equal(actual, expected);
   });
 
-  it('return the max if nearer to the max',function () {
-    var actual = getNearest([1, 13], 10);
-    var expected = 13;
+  it('return the unique point if it is lower',function () {
+    var actual = getNearestSmaller([5], 10);
+    var expected = 5;
 
     assert.equal(actual, expected);
   });
 
-  it('return the min if nearer to the min',function () {
-    var actual = getNearest([1, 13], 3);
+  it('return first if the number is in a range',function () {
+    var actual = getNearestSmaller([1, 12], 10);
     var expected = 1;
+
+    assert.equal(actual, expected);
+  });
+
+  it('return the last if the number is after the range',function () {
+    var actual = getNearestSmaller([1, 12], 15);
+    var expected = 12;
+
+    assert.equal(actual, expected);
+  });
+
+  it('return the value if it is equal',function () {
+    var actual = getNearestSmaller([7], 7);
+    var expected = 7;
 
     assert.equal(actual, expected);
   });


### PR DESCRIPTION
Make the progress-traker mark just the topics in the past of the
actual player time.