### PR TITLE
Fix #89

### DIFF
--- a/assets/sass/modules/_pagination.sass
+++ b/assets/sass/modules/_pagination.sass
@@ -29,7 +29,7 @@
   -o-transform: rotate(90deg)
   -ms-transform: rotate(90deg)
   -sand-transform: rotate(90deg)
-  transform: rotate(-90deg)
+  transform: rotate(90deg)
   display: block
 
 @media (max-width: 550px)

--- a/assets/sass/modules/_pagination.sass
+++ b/assets/sass/modules/_pagination.sass
@@ -14,12 +14,12 @@
 
 .pagination-prev
   float: left
-  transform: rotate(-90deg)
   -webkit-transform: rotate(-90deg)
   -moz-transform: rotate(-90deg)
   -o-transform: rotate(-90deg)
   -ms-transform: rotate(-90deg)
   -sand-transform: rotate(-90deg)
+  transform: rotate(-90deg)
   display: block
 
 .pagination-next
@@ -29,6 +29,7 @@
   -o-transform: rotate(90deg)
   -ms-transform: rotate(90deg)
   -sand-transform: rotate(90deg)
+  transform: rotate(-90deg)
   display: block
 
 @media (max-width: 550px)

--- a/assets/sass/modules/_pagination.sass
+++ b/assets/sass/modules/_pagination.sass
@@ -14,14 +14,22 @@
 
 .pagination-prev
   float: left
-  & img
-    transform: rotate(-90deg)
+  transform: rotate(-90deg)
+  -webkit-transform: rotate(-90deg)
+  -moz-transform: rotate(-90deg)
+  -o-transform: rotate(-90deg)
+  -ms-transform: rotate(-90deg)
+  -sand-transform: rotate(-90deg)
+  display: block
 
 .pagination-next
   float: right
-  & img
-    transform: rotate(90deg)
-
+  -webkit-transform: rotate(90deg)
+  -moz-transform: rotate(90deg)
+  -o-transform: rotate(90deg)
+  -ms-transform: rotate(90deg)
+  -sand-transform: rotate(90deg)
+  display: block
 
 @media (max-width: 550px)
   .pagination-prev img, .pagination-next img


### PR DESCRIPTION
OK, issue fixed. Turns out that in webkit-based browsers(Safari and Chrome), -webkit-transform is ignored on inline elements.. display block it is. I have also added some more browser prefixes.