### PR TITLE
Fix half-hidden episode player bar

### DIFF
--- a/components/Player.tsx
+++ b/components/Player.tsx
@@ -16,7 +16,7 @@ const Player = forwardRef<HTMLAudioElement, AudioPlayerProps>(({ title, url }, r
       p-4
       z-30
       fixed
-      -bottom-10
+      bottom-2
       transform
       transition-all
       duration-300


### PR DESCRIPTION
I tested to change the bottom from `-2.5` to `.5` and it works

<img width="1483" alt="Screenshot 2021-04-08 at 11 16 19" src="https://user-images.githubusercontent.com/1155694/114005519-e5d21e80-985f-11eb-910d-535a501ea8c6.png">

Fixing #151